### PR TITLE
storing the annotations into the machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export EXOSCALE_COMPUTE_ENDPOINT=https://api.exoscale.com/compute
 Run the `clusterctl` command.
 
 ```console
-% go run cmd/clusterctl/main.go create cluster \
+% go run cmd/clusterctl/main.go create cluster -v 9 \
         --provider exoscale \
         -m cmd/clusterctl/examples/exoscale/machine.yaml \
         -c cmd/clusterctl/examples/exoscale/cluster.yaml \
@@ -69,5 +69,5 @@ Same as above.
 ```
 
 ```console
-% go run cmd/manager/main.go
+% go run cmd/manager/main.go -v 9
 ```

--- a/README.md
+++ b/README.md
@@ -71,3 +71,50 @@ Same as above.
 ```console
 % go run cmd/manager/main.go -v 9
 ```
+
+## Using [KIND](https://github.com/kubernetes-sigs/kind)
+
+This is highly experimental...
+
+- https://github.com/kubernetes-sigs/cluster-api/pull/710
+
+
+```console
+% go run cmd/clusterctl/main.go create cluster -v 9 \
+        --provider exoscale \
+        -m cmd/clusterctl/examples/exoscale/machine.yaml \
+        -c cmd/clusterctl/examples/exoscale/cluster.yaml \
+        -p provider-components.yaml \
+        --bootstrap-type kind \
+        --bootstrap-flags "image=kindest/node:v1.12.3" \
+        --bootstrap-flags "config=kind-config.yaml" \
+        --bootstrap-flags "loglevel=debug"
+```
+
+...
+
+```yaml
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1alpha3
+    kind: ClusterConfiguration
+    networking:
+      serviceSubnet: 10.0.0.0/16
+    kubernetesVersion: v1.12.3
+  kubeadmConfigPatchesJson6902:
+  - group: kubeadm.k8s.io
+    version: v1alpha3
+    kind: ClusterConfiguration
+    patch: |
+      - op: add
+        path: /apiServerCertSANs/-
+        value: localhost
+- role: worker
+  replicas: 1
+```
+
+**NB** kubeadm v1.12 is `v1alpha3` when v1.13 is `v1beta`

--- a/cmd/clusterctl/examples/exoscale/machine.yaml
+++ b/cmd/clusterctl/examples/exoscale/machine.yaml
@@ -14,8 +14,6 @@ items:
         template: "Linux Ubuntu 18.04 LTS 64-bit"
         type: medium
         disk: 50
-        sshKey: id_rsa_cluster_api
-        securityGroup: cluster-api
     versions:
       kubelet: 1.12.5
       controlPlane: 1.12.5

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,11 +37,11 @@ import (
 // initLogs is a temporary hack to enable proper logging until upstream dependencies
 // are migrated to fully utilize klog instead of glog.
 func initLogs() {
-	flag.Set("logtostderr", "true")
+	flag.Set("logtostderr", "true") // nolint: errcheck
 	flags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(flags)
-	flags.Set("alsologtostderr", "true")
-	flags.Set("v", "3")
+	flags.Set("alsologtostderr", "true") // nolint: errcheck
+	flags.Set("v", "3")                  // nolint: errcheck
 	flag.Parse()
 }
 
@@ -88,9 +88,13 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	capimachine.AddWithActuator(mgr, machineActuator)
+	if err := capimachine.AddWithActuator(mgr, machineActuator); err != nil {
+		klog.Fatal(err)
+	}
 
-	capicluster.AddWithActuator(mgr, clusterActuator)
+	if err := capicluster.AddWithActuator(mgr, clusterActuator); err != nil {
+		klog.Fatal(err)
+	}
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		klog.Fatalf("unable to run manager: %v", err)

--- a/config/crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
+++ b/config/crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
@@ -33,10 +33,6 @@ spec:
           type: string
         metadata:
           type: object
-        securityGroup:
-          type: string
-        sshKey:
-          type: string
         template:
           type: string
         type:
@@ -47,8 +43,6 @@ spec:
           type: string
       required:
       - disk
-      - sshKey
-      - securityGroup
       - template
       - type
       - user

--- a/config/crds/exoscale_v1alpha1_exoscalemachineproviderstatus.yaml
+++ b/config/crds/exoscale_v1alpha1_exoscalemachineproviderstatus.yaml
@@ -14,18 +14,11 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        antiAffinityGroup:
-          type: string
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
-        cloudInit:
-          type: string
-        disk:
-          format: int64
-          type: integer
         id:
           type: object
         ip:
@@ -38,29 +31,22 @@ spec:
           type: string
         metadata:
           type: object
-        securityGroupID:
-          type: string
         sshKeyName:
           type: string
         sshPrivateKey:
           type: string
         templateID:
           type: object
-        type:
-          type: string
         user:
           type: string
         zone:
-          type: string
+          type: object
       required:
       - id
-      - disk
       - ip
-      - sshPrivateKey
       - sshKeyName
-      - securityGroupID
+      - sshPrivateKey
       - templateID
-      - type
       - user
       - zone
   version: v1alpha1

--- a/config/crds/exoscale_v1alpha1_exoscalemachineproviderstatus.yaml
+++ b/config/crds/exoscale_v1alpha1_exoscalemachineproviderstatus.yaml
@@ -39,7 +39,7 @@ spec:
           type: object
         user:
           type: string
-        zone:
+        zoneID:
           type: object
       required:
       - id
@@ -48,7 +48,7 @@ spec:
       - sshPrivateKey
       - templateID
       - user
-      - zone
+      - zoneID
   version: v1alpha1
 status:
   acceptedNames:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 - ../rbac/rbac_role.yaml
 - ../rbac/rbac_role_binding.yaml
 - ../manager/namespace.yaml
-- ../manager/manager.yaml
+#- ../manager/manager.yaml
 
 secretGenerator:
 - commands:
@@ -23,7 +23,7 @@ secretGenerator:
   type: Opaque
 
 patchesStrategicMerge:
-- manager_image_patch.yaml
+#- manager_image_patch.yaml
 
 patchesJson6902:
 - target:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 - ../rbac/rbac_role.yaml
 - ../rbac/rbac_role_binding.yaml
 - ../manager/namespace.yaml
-#- ../manager/manager.yaml
+- ../manager/manager.yaml
 
 secretGenerator:
 - commands:
@@ -23,7 +23,7 @@ secretGenerator:
   type: Opaque
 
 patchesStrategicMerge:
-#- manager_image_patch.yaml
+- manager_image_patch.yaml
 
 patchesJson6902:
 - target:

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderspec_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderspec_types.go
@@ -35,8 +35,6 @@ type ExoscaleMachineProviderSpec struct {
 	CloudInit         string `json:"cloudInit,omitempty"`
 	Disk              int64  `json:"disk"`
 	IPv6              bool   `json:"ipv6,omitempty"`
-	SSHKey            string `json:"sshKey"`
-	SecurityGroup     string `json:"securityGroup"`
 	Template          string `json:"template"`
 	Type              string `json:"type"`
 	User              string `json:"user"`

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
@@ -45,7 +45,7 @@ type ExoscaleMachineProviderStatus struct {
 	SSHPrivateKey string         `json:"sshPrivateKey"`
 	TemplateID    *egoscale.UUID `json:"templateID"`
 	User          string         `json:"user"`
-	ZoneID        *egoscale.UUID `json:"zone"`
+	ZoneID        *egoscale.UUID `json:"zoneID"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -54,7 +54,7 @@ func init() {
 	SchemeBuilder.Register(&ExoscaleMachineProviderStatus{})
 }
 
-//MachineStatusFromProviderStatus return machine provider status from provider status custom resources (/config/crds)
+// MachineStatusFromProviderStatus return machine provider specs from machine provider custom resources (/config/crds)
 func MachineStatusFromProviderStatus(providerStatus *runtime.RawExtension) (*ExoscaleMachineProviderStatus, error) {
 	config := new(ExoscaleMachineProviderStatus)
 	if providerStatus != nil {

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
@@ -39,19 +39,13 @@ type ExoscaleMachineProviderStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	ID                *egoscale.UUID `json:"id"`
-	AntiAffinityGroup string         `json:"antiAffinityGroup,omitempty"`
-	CloudInit         string         `json:"cloudInit,omitempty"`
-	Disk              int64          `json:"disk"`
-	IPv6              bool           `json:"ipv6,omitempty"`
-	IP                net.IP         `json:"ip"`
-	SSHPrivateKey     string         `json:"sshPrivateKey"`
-	SSHKeyName        string         `json:"sshKeyName"`
-	SecurityGroupID   string         `json:"securityGroupID"`
-	TemplateID        *egoscale.UUID `json:"templateID"`
-	Type              string         `json:"type"`
-	User              string         `json:"user"`
-	Zone              string         `json:"zone"`
+	ID            *egoscale.UUID `json:"id"`
+	IP            net.IP         `json:"ip"`
+	SSHKeyName    string         `json:"sshKeyName"`
+	SSHPrivateKey string         `json:"sshPrivateKey"`
+	TemplateID    *egoscale.UUID `json:"templateID"`
+	User          string         `json:"user"`
+	ZoneID        *egoscale.UUID `json:"zone"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
@@ -54,8 +54,8 @@ func init() {
 	SchemeBuilder.Register(&ExoscaleMachineProviderStatus{})
 }
 
-//MachineSpecFromMachineStatus return machine provider specs from machine provider custom resources (/config/crds)
-func MachineSpecFromMachineStatus(providerStatus *runtime.RawExtension) (*ExoscaleMachineProviderStatus, error) {
+//MachineStatusFromProviderStatus return machine provider status from provider status custom resources (/config/crds)
+func MachineStatusFromProviderStatus(providerStatus *runtime.RawExtension) (*ExoscaleMachineProviderStatus, error) {
 	config := new(ExoscaleMachineProviderStatus)
 	if providerStatus != nil {
 		if err := yaml.Unmarshal(providerStatus.Raw, config); err != nil {

--- a/pkg/apis/exoscale/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/exoscale/v1alpha1/zz_generated.deepcopy.go
@@ -126,6 +126,10 @@ func (in *ExoscaleMachineProviderStatus) DeepCopyInto(out *ExoscaleMachineProvid
 		in, out := &in.TemplateID, &out.TemplateID
 		*out = (*in).DeepCopy()
 	}
+	if in.ZoneID != nil {
+		in, out := &in.ZoneID, &out.ZoneID
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/cloud/exoscale/actuators/cluster/actuator.go
+++ b/pkg/cloud/exoscale/actuators/cluster/actuator.go
@@ -112,14 +112,14 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 
 	// Put the data into the "Status"
 	clusterStatus = &exoscalev1.ExoscaleClusterProviderStatus{
-		metav1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       "ExoscaleClusterProviderStatus",
 			APIVersion: "exoscale.cluster.k8s.io/v1alpha1",
 		},
-		metav1.ObjectMeta{
-			CreationTimestamp: metav1.Time{time.Now()},
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: time.Now()},
 		},
-		sgID,
+		SecurityGroupID: sgID,
 	}
 
 	if err := a.updateResources(clusterStatus, cluster); err != nil {

--- a/pkg/cloud/exoscale/actuators/cluster/actuator.go
+++ b/pkg/cloud/exoscale/actuators/cluster/actuator.go
@@ -97,8 +97,10 @@ func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 
 		_, err = exoClient.Request(egoscale.AuthorizeSecurityGroupIngress{
 			SecurityGroupID: sgID,
-			CIDRList:        []egoscale.CIDR{*egoscale.MustParseCIDR("0.0.0.0/0")},
-			Protocol:        "ALL",
+			CIDRList: []egoscale.CIDR{
+				*egoscale.MustParseCIDR("0.0.0.0/0"),
+				*egoscale.MustParseCIDR("::/0"),
+			},
 		})
 		if err != nil {
 			return fmt.Errorf("error creating or updating security group rule: %v", err)

--- a/pkg/cloud/exoscale/actuators/cluster/actuator.go
+++ b/pkg/cloud/exoscale/actuators/cluster/actuator.go
@@ -203,7 +203,7 @@ func (*Actuator) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (
 func (*Actuator) GetKubeConfig(cluster *clusterv1.Cluster, master *clusterv1.Machine) (string, error) {
 	klog.Infof("Getting Kubeconfig of the machine %v for cluster %v.", master.Name, cluster.Name)
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(master.Status.ProviderStatus)
+	machineStatus, err := exoscalev1.MachineStatusFromProviderStatus(master.Status.ProviderStatus)
 	if err != nil {
 		return "", fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
 	}

--- a/pkg/cloud/exoscale/actuators/cluster/actuator.go
+++ b/pkg/cloud/exoscale/actuators/cluster/actuator.go
@@ -191,18 +191,12 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster) error {
 func (*Actuator) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
 	klog.Infof("Getting IP of the machine %v for cluster %v.", machine.Name, cluster.Name)
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(machine.Status.ProviderStatus)
-	if err != nil {
-		return "", fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
-	}
-
-	if machineStatus.IP == nil {
+	annotations := machine.GetAnnotations()
+	if annotations == nil {
 		return "", errors.New("could not get IP")
 	}
 
-	println("IPIPIPIPIPIPIP:", machineStatus.IP.String(), ":IPIPIPIPIP")
-
-	return machineStatus.IP.String(), nil
+	return annotations[exoscalev1.ExoscaleIPAnnotationKey], nil
 }
 
 // GetKubeConfig gets a kubeconfig from the master.

--- a/pkg/cloud/exoscale/actuators/machine/actuator.go
+++ b/pkg/cloud/exoscale/actuators/machine/actuator.go
@@ -66,11 +66,6 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
 	}
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(machine.Status.ProviderStatus)
-	if err != nil {
-		return fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
-	}
-
 	if clusterStatus.SecurityGroupID == nil {
 		return fmt.Errorf("empty cluster securityGroupID field. %#v", clusterStatus)
 	}
@@ -187,21 +182,21 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return err
 	}
 
-	machineStatus = &exoscalev1.ExoscaleMachineProviderStatus{
-		metav1.TypeMeta{
+	machineStatus := &exoscalev1.ExoscaleMachineProviderStatus{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       "ExoscaleMachineProviderStatus",
 			APIVersion: "exoscale.cluster.k8s.io/v1alpha1",
 		},
-		metav1.ObjectMeta{
-			CreationTimestamp: metav1.Time{time.Now()},
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: time.Now()},
 		},
-		vm.ID,
-		*vm.IP(),
-		keyPairs.Name,
-		keyPairs.PrivateKey,
-		vm.TemplateID,
-		username,
-		vm.ZoneID,
+		ID:            vm.ID,
+		IP:            *vm.IP(),
+		SSHKeyName:    keyPairs.Name,
+		SSHPrivateKey: keyPairs.PrivateKey,
+		TemplateID:    vm.TemplateID,
+		User:          username,
+		ZoneID:        vm.ZoneID,
 	}
 
 	if err := a.updateResources(newMachine, machineStatus); err != nil {

--- a/pkg/cloud/exoscale/actuators/machine/actuator.go
+++ b/pkg/cloud/exoscale/actuators/machine/actuator.go
@@ -239,7 +239,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 		klog.Infof("deleting machine %q from %q.", machine.Name, cluster.Name)
 	}
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(machine.Status.ProviderStatus)
+	machineStatus, err := exoscalev1.MachineStatusFromProviderStatus(machine.Status.ProviderStatus)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal machine.Spec field: %v", err)
 	}
@@ -262,7 +262,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	klog.Infof("Updating machine %v for cluster %v.", machine.Name, cluster.Name)
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(machine.Status.ProviderStatus)
+	machineStatus, err := exoscalev1.MachineStatusFromProviderStatus(machine.Status.ProviderStatus)
 	if err != nil {
 		return fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
 	}
@@ -314,7 +314,7 @@ func (*Actuator) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (
 func (*Actuator) GetKubeConfig(cluster *clusterv1.Cluster, master *clusterv1.Machine) (string, error) {
 	klog.Infof("Getting Kubeconfig of the machine %v for cluster %v.", master.Name, cluster.Name)
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(master.Status.ProviderStatus)
+	machineStatus, err := exoscalev1.MachineStatusFromProviderStatus(master.Status.ProviderStatus)
 	if err != nil {
 		return "", fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
 	}

--- a/pkg/cloud/exoscale/actuators/machine/actuator.go
+++ b/pkg/cloud/exoscale/actuators/machine/actuator.go
@@ -300,20 +300,14 @@ func (a *Actuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 // GetIP returns IP address of the machine in the cluster.
 func (*Actuator) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	klog.Infof("Getting IP of machine %v for cluster %v.", machine.Name, cluster.Name)
+	klog.Infof("Getting IP of the machine %v for cluster %v.", machine.Name, cluster.Name)
 
-	machineStatus, err := exoscalev1.MachineSpecFromMachineStatus(machine.Status.ProviderStatus)
-	if err != nil {
-		return "", fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
-	}
-
-	if machineStatus.IP == nil {
+	annotations := machine.GetAnnotations()
+	if annotations == nil {
 		return "", errors.New("could not get IP")
 	}
 
-	println("IPIPIPIPIPIPIP:", machineStatus.IP.String(), ":IPIPIPIPIP")
-
-	return machineStatus.IP.String(), nil
+	return annotations[exoscalev1.ExoscaleIPAnnotationKey], nil
 }
 
 // GetKubeConfig gets a kubeconfig from the master.

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -31,6 +31,11 @@ const (
 	kindClusterName  = "clusterapi"
 )
 
+var (
+	// ignoredOptions lists the options not supported by delete and kubeconfig-path.
+	ignoredOptions = []string{"config", "image", "retain"}
+)
+
 type Kind struct {
 	options []string
 	// execFunc implemented as function variable for testing hooks
@@ -72,7 +77,14 @@ func (k *Kind) Create() error {
 
 func (k *Kind) Delete() error {
 	args := []string{"delete", "cluster"}
+
+outer:
 	for _, opt := range k.options {
+		for _, ignoredOption := range ignoredOptions {
+			if strings.HasPrefix(opt, ignoredOption) {
+				continue outer
+			}
+		}
 		args = append(args, fmt.Sprintf("--%v", opt))
 	}
 
@@ -96,7 +108,14 @@ func (k *Kind) GetKubeconfig() (string, error) {
 
 func (k *Kind) getKubeConfigPath() (string, error) {
 	args := []string{"get", "kubeconfig-path"}
+
+outer:
 	for _, opt := range k.options {
+		for _, ignoredOption := range ignoredOptions {
+			if strings.HasPrefix(opt, ignoredOption) {
+				continue outer
+			}
+		}
 		args = append(args, fmt.Sprintf("--%v", opt))
 	}
 


### PR DESCRIPTION
```console
% kubectl describe machines.cluster.k8s.io my-exoscale-master-p9q47
Name:         my-exoscale-master-p9q47
Namespace:    default
Labels:       set=master
Annotations:  exoscale-ip-address: 89.145.160.46
API Version:  cluster.k8s.io/v1alpha1
Kind:         Machine
Metadata:
  Creation Timestamp:  2019-01-25T09:17:33Z
  Finalizers:
    machine.cluster.k8s.io
  Generate Name:     my-exoscale-master-
  Generation:        1
  Resource Version:  925
  Self Link:         /apis/cluster.k8s.io/v1alpha1/namespaces/default/machines/my-exoscale-master-p9q47
  UID:               0c6e38ee-2082-11e9-b162-30d8ecbb6eea
Spec:
  Metadata:
    Creation Timestamp:  <nil>
  Provider Spec:
    Value:
      API Version:     exoscale.cluster.k8s.io/v1alpha1
      Disk:            50
      Kind:            ExoscaleMachineProviderSpec
      Security Group:  cluster-api
      Ssh Key:         id_rsa_cluster_api
      Template:        Linux Ubuntu 18.04 LTS 64-bit
      Type:            medium
      Zone:            de-fra-1
  Versions:
    Control Plane:  1.12.5
    Kubelet:        1.12.5
Status:
  Provider Status:
    API Version:  exoscale.cluster.k8s.io/v1alpha1
    Id:           a39fb1cf-a46e-4ef2-827c-f0fc8350b7fc
    Ip:           89.145.160.46
    Kind:         ExoscaleMachineProviderStatus
    Metadata:
      Creation Timestamp:  2019-01-25T09:21:01Z
    Ssh Key Name:          my-exoscale-master-p9q47_id_rsa
    Ssh Private Key:       -----BEGIN RSA PRIVATE KEY-----
<snip>
-----END RSA PRIVATE KEY-----

    Template ID:  0ba79797-88cd-4a1c-abf2-45c431e99744
    User:         ubuntu
    Zone:         de88c980-78f6-467c-a431-71bcc88e437f
Events:           <none>
```